### PR TITLE
Controller safety: dead-zone + homing on no-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ ros2 param set /robot_controller_node kp_vert 0.004
 ros2 param set /robot_controller_node kd_vert 0.0015
 ```
 
+3bis) Sécurité et stabilité (optionnel)
+
+- Réduire le micro‑tremblement près du centre:
+
+```bash
+ros2 param set /robot_controller_node dead_zone_px 12   # 8..16 recommandé
+```
+
+- Comportement si la cible disparaît (retour sécurité vers la pose initiale après un délai):
+
+```bash
+ros2 param set /robot_controller_node no_detection_behavior home
+ros2 param set /robot_controller_node no_detection_timeout_s 4.0   # 3..5 s
+```
+
 4) Ce que l’on doit voir
 
 - `/image_debug` (bounding boxes) via `rqt_image_view`

--- a/src/robo_pointer_visual/config/params.yaml
+++ b/src/robo_pointer_visual/config/params.yaml
@@ -86,3 +86,8 @@ robot_controller_node:
     #   lift: 45.0
     #   elbow: 45.0
     #   wrist: 90.0
+
+    # --- Safety / Stability (optional) ---
+    # dead_zone_px: 8            # ignore small pixel errors near image center
+    # no_detection_behavior: 'hold'  # 'hold' or 'home'
+    # no_detection_timeout_s: 3.0    # seconds without detection before applying 'home'


### PR DESCRIPTION
- Résumé: Améliore la stabilité/sécurité du suivi bras: suppression du micro‑tremblement près du centre via dead‑zone et retour automatique vers la pose initiale après perte de cible prolongée.
- Motivations: démo plus prévisible et sûre en conditions réelles, sans changer les interfaces ni les topics.
- Changements:
  - controller: paramètres `dead_zone_px`, `no_detection_behavior` ('hold'|'home'), `no_detection_timeout_s`; implémentation dead‑zone côté erreurs pixel; timer de homing respectant les limites deg/s; mise à jour dynamique via `on_set_parameters`.
  - config: ajoute les clés de sécurité (commentées) dans `params.yaml`.
  - docs: Quickstart enrichi avec les commandes de réglage recommandées.
- Comportement par défaut:
  - Backward‑compatible: dead‑zone par défaut modérée (8 px); `no_detection_behavior='hold'` (pas de homing si non activé).
- Validation:
  - Activer PID et tester:
    - `ros2 param set /robot_controller_node dead_zone_px 12`
    - `ros2 param set /robot_controller_node no_detection_behavior home`
    - `ros2 param set /robot_controller_node no_detection_timeout_s 4.0`
  - Vérifier que le bras reste stable proche du centre et revient progressivement à la pose initiale après ~4 s sans détection.
