### PR TITLE
Vision observability + optional static TF

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ ros2 topic hz /detected_target_point
 ros2 topic hz /target_joint_angles
 ros2 topic echo /detected_target_point --once
 ros2 topic list | rg 'joint_states|target_joint_angles'  # vérifier l'alignement des topics
+ros2 topic echo /detection_acquired --once   # true si la cible est acquise
+ros2 topic echo /detection_area --once       # aire du meilleur bbox
 ```
 
 5) Enregistrer un bag (20–30 s)

--- a/src/robo_pointer_visual/launch/pipeline.launch.py
+++ b/src/robo_pointer_visual/launch/pipeline.launch.py
@@ -38,6 +38,15 @@ def generate_launch_description():
     # Robot interface args
     read_freq = LaunchConfiguration('read_frequency_hz')
     enable_interface = LaunchConfiguration('enable_interface')
+    publish_static_tf = LaunchConfiguration('publish_static_tf')
+    tf_parent = LaunchConfiguration('tf_parent_frame')
+    tf_child = LaunchConfiguration('tf_child_frame')
+    tf_x = LaunchConfiguration('tf_x')
+    tf_y = LaunchConfiguration('tf_y')
+    tf_z = LaunchConfiguration('tf_z')
+    tf_roll = LaunchConfiguration('tf_roll')
+    tf_pitch = LaunchConfiguration('tf_pitch')
+    tf_yaw = LaunchConfiguration('tf_yaw')
 
     return LaunchDescription([
         # Decls
@@ -61,6 +70,15 @@ def generate_launch_description():
         DeclareLaunchArgument('joint_states_topic', default_value='joint_states'),
         DeclareLaunchArgument('target_joint_angles_topic', default_value='target_joint_angles'),
         DeclareLaunchArgument('enable_interface', default_value='true'),
+        DeclareLaunchArgument('publish_static_tf', default_value='false'),
+        DeclareLaunchArgument('tf_parent_frame', default_value='wrist_link'),
+        DeclareLaunchArgument('tf_child_frame', default_value='camera_frame'),
+        DeclareLaunchArgument('tf_x', default_value='0.0'),
+        DeclareLaunchArgument('tf_y', default_value='0.0'),
+        DeclareLaunchArgument('tf_z', default_value='0.0'),
+        DeclareLaunchArgument('tf_roll', default_value='0.0'),
+        DeclareLaunchArgument('tf_pitch', default_value='0.0'),
+        DeclareLaunchArgument('tf_yaw', default_value='0.0'),
 
         # Nodes
         Node(
@@ -112,5 +130,13 @@ def generate_launch_description():
                 'joint_states_topic': joint_states_topic,
                 'target_joint_angles_topic': target_joint_angles_topic,
             }]
+        ),
+        # Optional static TF for RViz visualization (Euler angles order: roll pitch yaw)
+        Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            name='static_camera_tf',
+            condition=IfCondition(publish_static_tf),
+            arguments=[tf_x, tf_y, tf_z, tf_roll, tf_pitch, tf_yaw, tf_parent, tf_child]
         ),
     ])


### PR DESCRIPTION
- Résumé: Améliore l’observabilité de la vision (topics /detection_acquired et /detection_area) et ajoute une option de TF statique pour faciliter la visualisation RViz.
- Motivations: diagnostiquer rapidement acquisition/perte de cible et la taille de la détection; simplifier la visualisation des frames caméra↔bras.
- Changements:
  - vision_node: nouveaux paramètres detection_acquired_topic et detection_area_topic; publications Bool et Float32 au rythme du timer.
  - launch: option publish_static_tf (bool) + frames/transform (x y z roll pitch yaw) et Node tf2_ros/static_transform_publisher conditionnel.
  - docs: ajout des topics diag dans le Quickstart.
- Fichiers:
  - src/robo_pointer_visual/robo_pointer_visual/vision_node.py
  - src/robo_pointer_visual/launch/pipeline.launch.py
  - README.md
- Compatibilité:
  - Aucun breaking change; topics additionnels relatifs par défaut; TF statique off par défaut.
- Validation:
  - ros2 launch robo_pointer_visual pipeline.launch.py
  - ros2 topic echo /detection_acquired --once (true/false)
  - ros2 topic echo /detection_area --once (nombre >0 si bbox)
  - ros2 launch robo_pointer_visual pipeline.launch.py publish_static_tf:=true tf_parent_frame:=wrist_link tf_child_frame:=camera_frame
