### PR TITLE
Tests: IK boundary tolerance fix

### DIFF
--- a/.github/workflows/pure-python-tests.yml
+++ b/.github/workflows/pure-python-tests.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest numpy
+      - name: Set PYTHONPATH
+        run: echo "PYTHONPATH=${GITHUB_WORKSPACE}/src/robo_pointer_visual" >> $GITHUB_ENV
       - name: Run pure kinematics tests only
-        run: |
-          pytest -q -k "kinematics" src/robo_pointer_visual/test
-
+        run: pytest -q -k "kinematics" src/robo_pointer_visual/test

--- a/.github/workflows/ros-python-tests.yml
+++ b/.github/workflows/ros-python-tests.yml
@@ -1,0 +1,49 @@
+name: ros-python-tests
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  ros-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup ROS 2 Humble
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
+      - name: Install ROS Python dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ros-humble-ros-base \
+            ros-humble-launch \
+            ros-humble-launch-ros \
+            ros-humble-geometry-msgs \
+            ros-humble-sensor-msgs \
+            ros-humble-ament-index-python
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest numpy
+      - name: Source ROS and set PYTHONPATH
+        shell: bash
+        run: |
+          echo "source /opt/ros/humble/setup.bash" >> $GITHUB_ENV
+          echo "PYTHONPATH=${GITHUB_WORKSPACE}/src/robo_pointer_visual" >> $GITHUB_ENV
+      - name: Run ROS-dependent Python tests
+        shell: bash
+        run: |
+          source /opt/ros/humble/setup.bash
+          pytest -q \
+            src/robo_pointer_visual/test/test_calibration_logic.py \
+            src/robo_pointer_visual/test/test_calibration_edges.py \
+            src/robo_pointer_visual/test/test_controller_safety.py \
+            src/robo_pointer_visual/test/test_launch_pipeline_structure.py \
+            src/robo_pointer_visual/test/test_mock_interface.py
+

--- a/src/robo_pointer_visual/test/test_kinematics_extra.py
+++ b/src/robo_pointer_visual/test/test_kinematics_extra.py
@@ -62,6 +62,14 @@ def test_aim_offset_axis_aligned():
     dx, dy = calculate_aim_offset(0.0, 30.0, d)
     assert math.isclose(dx, d, abs_tol=1e-9)
     assert math.isclose(dy, 0.0, abs_tol=1e-9)
+    # 90°: offset along +Y
+    dx, dy = calculate_aim_offset(90.0, 30.0, d)
+    assert math.isclose(dx, 0.0, abs_tol=1e-9)
+    assert math.isclose(dy, d, abs_tol=1e-9)
+    # 180°: offset along -X
+    dx, dy = calculate_aim_offset(180.0, 30.0, d)
+    assert math.isclose(dx, -d, abs_tol=1e-9)
+    assert math.isclose(dy, 0.0, abs_tol=1e-9)
 
 
 def test_ik_reach_boundaries():
@@ -70,21 +78,21 @@ def test_ik_reach_boundaries():
     target_y = 0.0
     th1, th2, ok = calculate_ik(target_x, target_y)
     assert ok is True
-    assert math.isclose(math.degrees(th1), 0.0, abs_tol=1e-6)
-    assert math.isclose(math.degrees(th2), 0.0, abs_tol=1e-6)
+    assert math.isclose(math.degrees(th1), 0.0, abs_tol=1e-4)
+    assert math.isclose(math.degrees(th2), 0.0, abs_tol=1e-4)
 
     # Minimum reach (fully folded): D = |L1 - L2|
     target_x = abs(L1 - L2)
     target_y = 0.0
     th1, th2, ok = calculate_ik(target_x, target_y)
     assert ok is True
-    assert math.isclose(math.degrees(th1), 0.0, abs_tol=1e-6)
-    assert math.isclose(math.degrees(th2), 180.0, abs_tol=1e-6)
+    assert math.isclose(math.degrees(th1), 0.0, abs_tol=1e-4)
+    assert math.isclose(math.degrees(th2), 180.0, abs_tol=1e-4)
 
 
 def test_ik_out_of_reach_boundaries():
     # Slightly beyond maximum reach should fail
-    eps = 1e-6
+    eps = 2e-6
     target_x = L1 + L2 + eps
     target_y = 0.0
     _, _, ok = calculate_ik(target_x, target_y)
@@ -115,11 +123,3 @@ def test_ik_zero_distance_unhandled():
     # At exactly 0 distance, IK should report failure per implementation guard
     _, _, ok = calculate_ik(0.0, 0.0)
     assert ok is False
-    # 90°: offset along +Y
-    dx, dy = calculate_aim_offset(90.0, 30.0, d)
-    assert math.isclose(dx, 0.0, abs_tol=1e-9)
-    assert math.isclose(dy, d, abs_tol=1e-9)
-    # 180°: offset along -X
-    dx, dy = calculate_aim_offset(180.0, 30.0, d)
-    assert math.isclose(dx, -d, abs_tol=1e-9)
-    assert math.isclose(dy, 0.0, abs_tol=1e-9)


### PR DESCRIPTION
Ajuste les tests IK pour éviter la fragilité numérique:
- Tolérance élargie à 1e-4 deg sur les cas limites (D=L1+L2, D=|L1-L2|).
- eps passé à 2e-6 (> TOLERANCE_REACH=1e-6) pour que le cas "juste hors portée" soit bien détecté.\nAucun impact runtime; rend la CI plus robuste.