### PR TITLE
Demo ergonomics: start script mock mode + param profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,17 @@ ros2 topic echo /detection_acquired --once   # true si la cible est acquise
 ros2 topic echo /detection_area --once       # aire du meilleur bbox
 ```
 
-5) Enregistrer un bag (20–30 s)
+5) Charger des profils de démo (optionnel)
+
+```bash
+# Profil mock recommandé (PID ON, dead-zone 12, homing):
+ros2 param load /robot_controller_node install/robo_pointer_visual/share/robo_pointer_visual/config/demo_mock.yaml
+
+# Profil réel (PID OFF au démarrage, vitesses conservatrices):
+ros2 param load /robot_controller_node install/robo_pointer_visual/share/robo_pointer_visual/config/demo_real.yaml
+```
+
+6) Enregistrer un bag (20–30 s)
 
 ```bash
 ros2 bag record -O follower_arm_demo \
@@ -99,7 +109,7 @@ ros2 bag record -O follower_arm_demo \
 # Stopper l’enregistrement après 20–30 secondes (Ctrl+C)
 ```
 
-6) Rejouer le bag (test offline du contrôleur)
+7) Rejouer le bag (test offline du contrôleur)
 
 Cas A — Relecture des topics pour inspection:
 
@@ -118,7 +128,7 @@ ros2 bag play follower_arm_demo
 ros2 run robo_pointer_visual robot_controller_node --ros-args -p use_pid_control:=true
 ```
 
-7) Vérifications TF et diag (optionnel)
+8) Vérifications TF et diag (optionnel)
 
 - Pour visualiser les TF en RViz: `ros2 launch so100_description display.launch.py`
 - Echo TF (si robot_state_publisher lancé):
@@ -278,7 +288,11 @@ Rendez le script de lancement exécutable et lancez-le :
 ```bash
 chmod +x ~/ros2_ws/scripts/start_robot.sh
 cd ~/ros2_ws
-./scripts/start_robot.sh
+# Mode réel (par défaut):
+./scripts/start_robot.sh [nano|medium|large]
+
+# Mode mock (offline complet):
+./scripts/start_robot.sh mock [nano|medium|large]
 ```
 
 Le script crée une session `tmux` nommée `robot_dev` avec trois panneaux :

--- a/src/robo_pointer_visual/config/demo_mock.yaml
+++ b/src/robo_pointer_visual/config/demo_mock.yaml
@@ -1,0 +1,14 @@
+robot_controller_node:
+  ros__parameters:
+    # Enable PID and smoothing for a stable mock demo
+    use_pid_control: true
+    dead_zone_px: 12
+    no_detection_behavior: 'home'
+    no_detection_timeout_s: 4.0
+    # Safe per-joint speeds (deg/s)
+    joint_speed_max_deg_s:
+      pan: 60.0
+      lift: 45.0
+      elbow: 45.0
+      wrist: 90.0
+

--- a/src/robo_pointer_visual/config/demo_real.yaml
+++ b/src/robo_pointer_visual/config/demo_real.yaml
@@ -1,0 +1,14 @@
+robot_controller_node:
+  ros__parameters:
+    # Start without PID; enable gradually when stable
+    use_pid_control: false
+    dead_zone_px: 14
+    no_detection_behavior: 'home'
+    no_detection_timeout_s: 4.0
+    # Conservative per-joint speeds (deg/s) for first trials
+    joint_speed_max_deg_s:
+      pan: 30.0
+      lift: 20.0
+      elbow: 20.0
+      wrist: 60.0
+


### PR DESCRIPTION
- scripts/start_robot.sh: support 'mock' mode to start mock_robot_interface instead of real interface.
- config: add demo_mock.yaml (PID ON, dead-zone, homing) and demo_real.yaml (PID OFF initially, conservative speeds).
- README: Quickstart updated to show start script usage (real/mock) and param loading examples.
- Commits atomiques par thème pour un review clair.