### PR TITLE
demo(mock): mock_demo.sh + live_status.py; wrapper ros2_cli; docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ source ~/ros2_ws/install/setup.bash
 
 2) Lancer la pipeline bras (YOLO → controller → interface)
 
+Option A — Script mock (recommandé pour la démo)
+
+```bash
+# lance vision + contrôleur + interface mock, puis vérifie les topics
+scripts/mock_demo.sh               # auto: yolov8n.pt et /dev/video0
+# monitoring 1‑fenêtre (taux + statut):
+source scripts/env.sh && python3 scripts/live_status.py
+```
+
+Option B — Commande launch directe
+
 ```bash
 ros2 launch robo_pointer_visual pipeline.launch.py \
   yolo_model:=/home/benja/ros2_ws/yolov8n.pt \
@@ -83,12 +94,13 @@ ros2 param set /robot_controller_node no_detection_timeout_s 4.0   # 3..5 s
 Commandes utiles:
 
 ```bash
-ros2 topic hz /detected_target_point
-ros2 topic hz /target_joint_angles
-ros2 topic echo /detected_target_point --once
-ros2 topic list | rg 'joint_states|target_joint_angles'  # vérifier l'alignement des topics
-ros2 topic echo /detection_acquired --once   # true si la cible est acquise
-ros2 topic echo /detection_area --once       # aire du meilleur bbox
+# Utiliser le wrapper CLI propre pour éviter les conflits conda/ROS
+scripts/ros2_cli.sh topic hz /detected_target_point
+scripts/ros2_cli.sh topic hz /target_joint_angles
+scripts/ros2_cli.sh topic echo /detected_target_point --once
+scripts/ros2_cli.sh topic list | rg 'joint_states|target_joint_angles'
+scripts/ros2_cli.sh topic echo /detection_acquired --once
+scripts/ros2_cli.sh topic echo /detection_area --once
 ```
 
 5) Charger des profils de démo (optionnel)

--- a/scripts/live_status.py
+++ b/scripts/live_status.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Live status dashboard (one terminal) for the mock/real pipeline.
+
+Shows per-second rates for core topics and the latest detection status/values.
+
+Usage:
+  source scripts/env.sh
+  python3 scripts/live_status.py
+
+Stop with Ctrl+C.
+"""
+
+import time
+import sys
+from dataclasses import dataclass
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+
+from std_msgs.msg import Bool, Float32
+from geometry_msgs.msg import Point
+from sensor_msgs.msg import Image, JointState
+
+
+@dataclass
+class TopicStats:
+    count: int = 0
+    last_count: int = 0
+    last_rate: float = 0.0
+
+
+class LiveStatus(Node):
+    def __init__(self):
+        super().__init__('live_status')
+
+        qos = QoSProfile(depth=10)
+        qos.reliability = ReliabilityPolicy.RELIABLE
+        qos.history = HistoryPolicy.KEEP_LAST
+
+        self.stats = {
+            'image_debug': TopicStats(),
+            'detected_target_point': TopicStats(),
+            'target_joint_angles': TopicStats(),
+            'joint_states': TopicStats(),
+            'detection_acquired': TopicStats(),
+            'detection_area': TopicStats(),
+        }
+
+        self.last_point = Point()
+        self.acquired = False
+        self.area = 0.0
+        self.last_target_joint_names = []
+        self.last_target_joint_deg = []
+
+        self.create_subscription(Image, 'image_debug', self._on_image, qos)
+        self.create_subscription(Point, 'detected_target_point', self._on_point, qos)
+        self.create_subscription(JointState, 'target_joint_angles', self._on_target_js, qos)
+        self.create_subscription(JointState, 'joint_states', self._on_js, qos)
+        self.create_subscription(Bool, 'detection_acquired', self._on_acq, qos)
+        self.create_subscription(Float32, 'detection_area', self._on_area, qos)
+
+        self.timer = self.create_timer(1.0, self._tick)
+        self.started = time.time()
+
+    def _bump(self, key: str):
+        if key in self.stats:
+            self.stats[key].count += 1
+
+    def _on_image(self, _msg: Image):
+        self._bump('image_debug')
+
+    def _on_point(self, msg: Point):
+        self._bump('detected_target_point')
+        self.last_point = msg
+
+    def _on_target_js(self, msg: JointState):
+        self._bump('target_joint_angles')
+        self.last_target_joint_names = list(msg.name)
+        try:
+            self.last_target_joint_deg = [v * 180.0 / 3.141592653589793 for v in msg.position]
+        except Exception:
+            self.last_target_joint_deg = []
+
+    def _on_js(self, _msg: JointState):
+        self._bump('joint_states')
+
+    def _on_acq(self, msg: Bool):
+        self._bump('detection_acquired')
+        self.acquired = bool(msg.data)
+
+    def _on_area(self, msg: Float32):
+        self._bump('detection_area')
+        self.area = float(msg.data)
+
+    def _rate_line(self, key: str, label: str) -> str:
+        st = self.stats[key]
+        delta = st.count - st.last_count
+        st.last_count = st.count
+        st.last_rate = delta  # since we print once per second
+        return f"{label:<22} {st.last_rate:6.2f} Hz"
+
+    def _pubs(self, topic: str) -> int:
+        try:
+            infos = self.get_publishers_info_by_topic(topic)
+            return len(infos)
+        except Exception:
+            return 0
+
+    def _tick(self):
+        now = time.time()
+        uptime = now - self.started
+        try:
+            # Clear-like header (keep it simple without ANSI control codes)
+            print("\n" * 2, end="")
+            print("Live Status (1s refresh) — uptime: %.0fs" % uptime)
+            print("Topics present — pubs: image_debug=%d, target=%d, target_angles=%d, joint_states=%d" % (
+                self._pubs('image_debug'),
+                self._pubs('detected_target_point'),
+                self._pubs('target_joint_angles'),
+                self._pubs('joint_states'),
+            ))
+            print(self._rate_line('image_debug', 'image_debug'))
+            print(self._rate_line('detected_target_point', 'detected_target_point'))
+            print(self._rate_line('target_joint_angles', 'target_joint_angles'))
+            print(self._rate_line('joint_states', 'joint_states'))
+            print(self._rate_line('detection_acquired', 'detection_acquired'))
+            print(self._rate_line('detection_area', 'detection_area'))
+
+            lp = self.last_point
+            print("Detection: acquired=%s  area=%.1f  point=(%.1f, %.1f)" % (
+                str(self.acquired), self.area, getattr(lp, 'x', -1.0), getattr(lp, 'y', -1.0)))
+
+            if self.last_target_joint_names and self.last_target_joint_deg:
+                pairs = [f"{n}={d:.1f}°" for n, d in zip(self.last_target_joint_names, self.last_target_joint_deg)]
+                print("Target angles: ", ", ".join(pairs))
+            sys.stdout.flush()
+        except Exception as e:
+            # Keep running even if printing fails
+            print(f"[status] print error: {e}")
+
+
+def main():
+    rclpy.init()
+    node = LiveStatus()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/mock_demo.sh
+++ b/scripts/mock_demo.sh
@@ -182,9 +182,10 @@ fi
 
 # 7) Show one sample message from each key topic
 echo "[info] Sampling topics (once each)..."
-ros2 topic echo /detected_target_point --once --qos-durability volatile --qos-reliability reliable || true
-ros2 topic echo /target_joint_angles --once --qos-durability volatile --qos-reliability reliable || true
-ros2 topic echo /joint_states --once --qos-durability volatile --qos-reliability reliable || true
+ROS2_CLI="$REPO_ROOT/scripts/ros2_cli.sh"
+"$ROS2_CLI" topic echo /detected_target_point --once --qos-durability volatile --qos-reliability reliable || true
+"$ROS2_CLI" topic echo /target_joint_angles --once --qos-durability volatile --qos-reliability reliable || true
+"$ROS2_CLI" topic echo /joint_states --once --qos-durability volatile --qos-reliability reliable || true
 
 cat <<EOF
 [next]

--- a/scripts/mock_demo.sh
+++ b/scripts/mock_demo.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Mock end-to-end demo launcher for robo_pointer_visual
+# - Starts the full pipeline with the mock interface
+# - Verifies key topics are up and prints sample messages
+# Usage:
+#   scripts/mock_demo.sh [nano|medium|large|/path/to/weights.pt] [camera_device]
+# Examples:
+#   scripts/mock_demo.sh            # auto-pick yolov8n.pt and /dev/video0
+#   scripts/mock_demo.sh nano /dev/video2
+#   scripts/mock_demo.sh /home/benja/ros2_ws/yolov8m.pt /dev/video0
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+
+# 1) Environment (ROS overlay + PYTHONPATH)
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/env.sh" >/dev/null 2>&1 || true
+
+if ! command -v ros2 >/dev/null 2>&1; then
+  echo "[err] ros2 not found in PATH. Ensure ROS 2 Humble is installed and sourced." >&2
+  exit 2
+fi
+
+# 2) Resolve weights and camera
+WEIGHTS_SEL="${1:-auto}"
+CAMERA_DEV="${2:-/dev/video0}"
+
+pick_weights() {
+  case "$1" in
+    nano) echo "$REPO_ROOT/yolov8n.pt" ;;
+    medium) echo "$REPO_ROOT/yolov8m.pt" ;;
+    large) echo "$REPO_ROOT/yolov8l.pt" ;;
+    auto|*)
+      for f in "$REPO_ROOT/yolov8n.pt" "$REPO_ROOT/yolov8m.pt" "$REPO_ROOT/yolov8l.pt"; do
+        [ -f "$f" ] && echo "$f" && return 0
+      done
+      # Fall back to the provided arg if it's a path
+      [ -f "$1" ] && echo "$1" && return 0
+      echo "" ;;
+  esac
+}
+
+YOLO_WEIGHTS="$(pick_weights "$WEIGHTS_SEL")"
+if [ -z "$YOLO_WEIGHTS" ] || [ ! -f "$YOLO_WEIGHTS" ]; then
+  echo "[err] YOLO weights not found. Place yolov8n.pt in repo root or pass a path." >&2
+  exit 3
+fi
+
+STAMP="$(date +%F_%H-%M-%S)"
+LOGFILE="/tmp/mock_pipeline_${STAMP}.log"
+
+echo "[info] Starting mock pipeline..."
+echo "       weights = $YOLO_WEIGHTS"
+echo "       camera  = $CAMERA_DEV"
+echo "       log     = $LOGFILE"
+
+# 3) Launch full pipeline (vision + controller + mock interface)
+set +e
+nohup ros2 launch robo_pointer_visual pipeline.launch.py \
+  yolo_model:="$YOLO_WEIGHTS" \
+  interface_type:=mock \
+  camera_index:="$CAMERA_DEV" \
+  device:=auto \
+  publish_rate_hz:=15.0 \
+  publish_static_tf:=true \
+  tf_parent_frame:=Wrist_Pitch_Roll \
+  tf_child_frame:=camera_frame \
+  > "$LOGFILE" 2>&1 &
+LAUNCH_PID=$!
+set -e
+
+cleanup() {
+  echo
+  echo "[info] Stopping mock pipeline (PID=$LAUNCH_PID)..."
+  kill "$LAUNCH_PID" 2>/dev/null || true
+}
+trap cleanup INT TERM
+
+# 4) Wait for key topics
+echo "[info] Waiting for topics: /joint_states, /target_joint_angles, /image_debug"
+for i in $(seq 1 60); do
+  TL="$(ros2 topic list 2>/dev/null | tr '\n' ' ')"
+  if echo "$TL" | grep -q "/joint_states" && \
+     echo "$TL" | grep -q "/target_joint_angles" && \
+     echo "$TL" | grep -q "/image_debug" ; then
+    echo "[ok] Topics are up."
+    break
+  fi
+  sleep 0.5
+  if [ "$i" -eq 60 ]; then
+    echo "[warn] Topics not detected in time. Current list:"; ros2 topic list || true
+  fi
+done
+
+# 5) Optional: Load mock controller profile if available (non-fatal)
+PROFILE_PATH="$(ros2 pkg prefix robo_pointer_visual 2>/dev/null)/share/robo_pointer_visual/config/demo_mock.yaml"
+if [ -f "$PROFILE_PATH" ]; then
+  ros2 param load /robot_controller_node "$PROFILE_PATH" >/dev/null 2>&1 || true
+fi
+
+# 6) Show one sample message from each key topic
+echo "[info] Sampling topics (once each)..."
+ros2 topic echo /detected_target_point --once --qos-durability volatile --qos-reliability reliable || true
+ros2 topic echo /target_joint_angles --once --qos-durability volatile --qos-reliability reliable || true
+ros2 topic echo /joint_states --once --qos-durability volatile --qos-reliability reliable || true
+
+cat <<EOF
+[next]
+- Open rqt_image_view and select /image_debug to see detections.
+- In RViz (optional), set Fixed Frame=Base and add TF + RobotModel.
+- Adjust parameters live if needed, e.g.:
+    ros2 param set /robot_controller_node dead_zone_px 12
+    ros2 param set /robot_controller_node use_pid_control false
+EOF
+
+echo "[info] Mock pipeline running (PID=$LAUNCH_PID). Press Ctrl+C to stop."
+wait "$LAUNCH_PID"

--- a/scripts/mock_demo.sh
+++ b/scripts/mock_demo.sh
@@ -2,16 +2,40 @@
 # Mock end-to-end demo launcher for robo_pointer_visual
 # - Starts the full pipeline with the mock interface
 # - Verifies key topics are up and prints sample messages
+# - Optional: records a bag and customizes common parameters
+#
 # Usage:
-#   scripts/mock_demo.sh [nano|medium|large|/path/to/weights.pt] [camera_device]
+#   scripts/mock_demo.sh [-w {nano|medium|large|/path/to/weights.pt}] \
+#                        [-c CAMERA] [-t CLASS] [-d {auto|cpu|cuda}] \
+#                        [-p PUB_HZ] [-r FPS] [-W WIDTH] [-H HEIGHT] \
+#                        [-C CONF] [-B BAG_BASENAME] [-- no-static-tf]
 # Examples:
-#   scripts/mock_demo.sh            # auto-pick yolov8n.pt and /dev/video0
-#   scripts/mock_demo.sh nano /dev/video2
-#   scripts/mock_demo.sh /home/benja/ros2_ws/yolov8m.pt /dev/video0
+#   scripts/mock_demo.sh                            # auto: yolov8n.pt, /dev/video0
+#   scripts/mock_demo.sh -w nano -c /dev/video2     # nano weights, specific camera
+#   scripts/mock_demo.sh -w ~/ros2_ws/yolov8m.pt -C 0.35 -t bottle
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+Options:
+  -w PATH|nano|medium|large   YOLO weights (default: auto search in repo)
+  -c CAMERA                   Camera index/path (default: /dev/video0)
+  -t CLASS                    Target class name (default: bottle)
+  -d DEVICE                   Device auto|cpu|cuda (default: auto)
+  -p HZ                       Publish rate Hz (default: 15.0)
+  -r FPS                      Camera FPS (default: 30.0)
+  -W WIDTH                    Frame width (default: 640)
+  -H HEIGHT                   Frame height (default: 480)
+  -C CONF                     Confidence threshold [0,1] (default: 0.5)
+  -B BASENAME                 Record rosbag to BASENAME (optional)
+  -- no-static-tf             Do not publish static camera TF
+  -h                          Show this help
+USAGE
+}
 
 # 1) Environment (ROS overlay + PYTHONPATH)
 # shellcheck disable=SC1091
@@ -22,9 +46,39 @@ if ! command -v ros2 >/dev/null 2>&1; then
   exit 2
 fi
 
-# 2) Resolve weights and camera
-WEIGHTS_SEL="${1:-auto}"
-CAMERA_DEV="${2:-/dev/video0}"
+# 2) Parse CLI
+WEIGHTS_SEL="auto"
+CAMERA_DEV="/dev/video0"
+TARGET_CLASS="bottle"
+DEVICE_SEL="auto"
+PUB_HZ="15.0"
+FPS="30.0"
+WIDTH="640"
+HEIGHT="480"
+CONF="0.5"
+BAG_BASENAME=""
+PUBLISH_STATIC_TF="true"
+
+while (( "$#" )); do
+  case "$1" in
+    -w) WEIGHTS_SEL="${2:-}"; shift 2;;
+    -c) CAMERA_DEV="${2:-}"; shift 2;;
+    -t) TARGET_CLASS="${2:-}"; shift 2;;
+    -d) DEVICE_SEL="${2:-}"; shift 2;;
+    -p) PUB_HZ="${2:-}"; shift 2;;
+    -r) FPS="${2:-}"; shift 2;;
+    -W) WIDTH="${2:-}"; shift 2;;
+    -H) HEIGHT="${2:-}"; shift 2;;
+    -C) CONF="${2:-}"; shift 2;;
+    -B) BAG_BASENAME="${2:-}"; shift 2;;
+    --) shift; break;;
+    --no-static-tf) PUBLISH_STATIC_TF="false"; shift;;
+    -h|--help) usage; exit 0;;
+    *)
+      echo "[warn] Unknown option: $1" >&2
+      usage; exit 1;;
+  esac
+done
 
 pick_weights() {
   case "$1" in
@@ -51,29 +105,46 @@ STAMP="$(date +%F_%H-%M-%S)"
 LOGFILE="/tmp/mock_pipeline_${STAMP}.log"
 
 echo "[info] Starting mock pipeline..."
-echo "       weights = $YOLO_WEIGHTS"
-echo "       camera  = $CAMERA_DEV"
-echo "       log     = $LOGFILE"
+echo "       weights  = $YOLO_WEIGHTS"
+echo "       camera   = $CAMERA_DEV"
+echo "       class    = $TARGET_CLASS"
+echo "       device   = $DEVICE_SEL"
+echo "       img      = ${WIDTH}x${HEIGHT}@${FPS}"
+echo "       pub_hz   = $PUB_HZ"
+echo "       conf     = $CONF"
+echo "       staticTF = $PUBLISH_STATIC_TF"
+echo "       log      = $LOGFILE"
 
 # 3) Launch full pipeline (vision + controller + mock interface)
 set +e
+set -m  # enable job control to obtain process group id
 nohup ros2 launch robo_pointer_visual pipeline.launch.py \
   yolo_model:="$YOLO_WEIGHTS" \
   interface_type:=mock \
   camera_index:="$CAMERA_DEV" \
-  device:=auto \
-  publish_rate_hz:=15.0 \
-  publish_static_tf:=true \
+  device:="$DEVICE_SEL" \
+  publish_rate_hz:="$PUB_HZ" \
+  confidence_threshold:="$CONF" \
+  frame_rate:="$FPS" \
+  frame_width:="$WIDTH" \
+  frame_height:="$HEIGHT" \
+  target_class_name:="$TARGET_CLASS" \
+  publish_static_tf:="$PUBLISH_STATIC_TF" \
   tf_parent_frame:=Wrist_Pitch_Roll \
   tf_child_frame:=camera_frame \
   > "$LOGFILE" 2>&1 &
 LAUNCH_PID=$!
+LAUNCH_PGID="$(ps -o pgid= "$LAUNCH_PID" | tr -d '[:space:]')"
 set -e
 
 cleanup() {
   echo
-  echo "[info] Stopping mock pipeline (PID=$LAUNCH_PID)..."
-  kill "$LAUNCH_PID" 2>/dev/null || true
+  echo "[info] Stopping mock pipeline (PID=$LAUNCH_PID, PGID=$LAUNCH_PGID)..."
+  # Try graceful stop first
+  kill -INT "$LAUNCH_PID" 2>/dev/null || true
+  sleep 0.5
+  # Ensure process group is terminated
+  kill -TERM -"$LAUNCH_PGID" 2>/dev/null || true
 }
 trap cleanup INT TERM
 
@@ -99,7 +170,17 @@ if [ -f "$PROFILE_PATH" ]; then
   ros2 param load /robot_controller_node "$PROFILE_PATH" >/dev/null 2>&1 || true
 fi
 
-# 6) Show one sample message from each key topic
+# 6) Optional bag record
+if [ -n "$BAG_BASENAME" ]; then
+  echo "[info] Recording rosbag: $BAG_BASENAME"
+  ros2 bag record -O "$BAG_BASENAME" \
+    /image_debug /detected_target_point /joint_states /target_joint_angles \
+    >/dev/null 2>&1 &
+  BAG_PID=$!
+  trap 'cleanup; kill "$BAG_PID" 2>/dev/null || true' INT TERM
+fi
+
+# 7) Show one sample message from each key topic
 echo "[info] Sampling topics (once each)..."
 ros2 topic echo /detected_target_point --once --qos-durability volatile --qos-reliability reliable || true
 ros2 topic echo /target_joint_angles --once --qos-durability volatile --qos-reliability reliable || true

--- a/scripts/ros2_cli.sh
+++ b/scripts/ros2_cli.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Wrapper to run ROS 2 CLI commands in a clean environment to avoid PYTHONPATH/conda conflicts.
+# Usage: scripts/ros2_cli.sh <ros2 subcommand...>
+
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+  echo "Usage: $(basename "$0") <ros2 args...>" >&2
+  exit 1
+fi
+
+CMD=("$@")
+
+# Preserve minimal env needed for terminals/X11, reconstruct ROS env
+env -i HOME="$HOME" TERM="${TERM:-xterm-256color}" DISPLAY="${DISPLAY:-}" \
+  bash -lc '
+    source /opt/ros/humble/setup.bash
+    # Avoid user site interference
+    export PYTHONNOUSERSITE=1
+    exec ros2 "$@"
+  ' bash "${CMD[@]}"
+

--- a/src/robo_pointer_visual/launch/pipeline.launch.py
+++ b/src/robo_pointer_visual/launch/pipeline.launch.py
@@ -39,6 +39,7 @@ def generate_launch_description():
     read_freq = LaunchConfiguration('read_frequency_hz')
     enable_interface = LaunchConfiguration('enable_interface')
     interface_type = LaunchConfiguration('interface_type')
+    enable_torque = LaunchConfiguration('enable_torque')
     publish_static_tf = LaunchConfiguration('publish_static_tf')
     tf_parent = LaunchConfiguration('tf_parent_frame')
     tf_child = LaunchConfiguration('tf_child_frame')
@@ -72,6 +73,7 @@ def generate_launch_description():
         DeclareLaunchArgument('target_joint_angles_topic', default_value='target_joint_angles'),
         DeclareLaunchArgument('enable_interface', default_value='true'),
         DeclareLaunchArgument('interface_type', default_value='real'),  # real|mock|none
+        DeclareLaunchArgument('enable_torque', default_value='true'),
         DeclareLaunchArgument('publish_static_tf', default_value='false'),
         DeclareLaunchArgument('tf_parent_frame', default_value='wrist_link'),
         DeclareLaunchArgument('tf_child_frame', default_value='camera_frame'),
@@ -131,6 +133,7 @@ def generate_launch_description():
                 'leader_arm_port': leader_arm_port,
                 'joint_states_topic': joint_states_topic,
                 'target_joint_angles_topic': target_joint_angles_topic,
+                'enable_torque': enable_torque,
             }]
         ),
         Node(

--- a/src/robo_pointer_visual/robo_pointer_visual/real_robot_interface.py
+++ b/src/robo_pointer_visual/robo_pointer_visual/real_robot_interface.py
@@ -7,6 +7,7 @@ from rclpy.node import Node
 from rclpy.executors import SingleThreadedExecutor
 from geometry_msgs.msg import Vector3
 from sensor_msgs.msg import JointState
+from rcl_interfaces.msg import SetParametersResult
 import traceback
 from ament_index_python.packages import get_package_share_directory
 from typing import Tuple, Optional, Dict, Any, List
@@ -160,6 +161,8 @@ class RealRobotInterfaceNode(Node):
             # Paramètres
             self.declare_parameter('leader_arm_port', LEADER_ARM_PORT)
             self.declare_parameter('read_frequency_hz', 20.0)
+            # Dry-run: n'active pas le couple et n'envoie pas de commandes moteurs
+            self.declare_parameter('enable_torque', True)
             # Topics (relatifs par défaut, pour supporter le namespacing)
             self.declare_parameter('joint_states_topic', 'joint_states')
             self.declare_parameter('target_joint_angles_topic', 'target_joint_angles')
@@ -167,7 +170,12 @@ class RealRobotInterfaceNode(Node):
             self._load_calibration_file()
             self._connect_motor_bus()
             self._initialize_group_sync_handlers()
-            self._initialize_motors_torque()
+
+            self.enable_torque = bool(self.get_parameter('enable_torque').get_parameter_value().bool_value)
+            if self.enable_torque:
+                self._initialize_motors_torque()
+            else:
+                self.get_logger().warn("enable_torque=false: DRY-RUN active (no torque, no motor commands)")
             read_frequency = self.get_parameter('read_frequency_hz').get_parameter_value().double_value
             
             joint_states_topic = self.get_parameter('joint_states_topic').get_parameter_value().string_value
@@ -178,6 +186,8 @@ class RealRobotInterfaceNode(Node):
                 JointState, target_joint_angles_topic, self.target_angles_callback, 10
             )
             self.read_publish_timer = self.create_timer(1.0 / read_frequency, self.read_and_publish_states)
+            # Dynamic param updates
+            self.add_on_set_parameters_callback(self.on_set_parameters)
             
             self.get_logger().info('Node initialized successfully. Ready to execute commands.')
 
@@ -239,6 +249,17 @@ class RealRobotInterfaceNode(Node):
                  self.get_logger().warn(f"Torque enable for {name}(ID:{motor_id}) potentially failed.")
             time.sleep(0.02)
         self.get_logger().info("Motor torque enabled.")
+
+    def _disable_motors_torque(self):
+        self.get_logger().info("Disabling torque for all motors (dry-run)...")
+        addr_torque = SCS_CONTROL_TABLE["Torque_Enable"][0]
+        for name in MOTOR_NAMES_ORDER:
+            motor_id = LEADER_ARM_MOTORS[name][0]
+            scs_comm_result, _ = self.packet_handler.write1ByteTxRx(self.port_handler, motor_id, addr_torque, 0)
+            if scs_comm_result != scs.COMM_SUCCESS:
+                 self.get_logger().warn(f"Torque disable for {name}(ID:{motor_id}) potentially failed.")
+            time.sleep(0.02)
+        self.get_logger().info("Motor torque disabled.")
         
     def read_and_publish_states(self):
         if not self.reader_motors_ok: return
@@ -277,6 +298,9 @@ class RealRobotInterfaceNode(Node):
 
     def target_angles_callback(self, msg: JointState):
         self.get_logger().debug(f"Received target angles for joints: {msg.name}")
+        if not getattr(self, 'enable_torque', True):
+            # Dry-run: ignore outgoing motor commands
+            return
         target_motor_names = msg.name
         target_angles_rad = msg.position
         target_angles_deg = [math.degrees(angle) for angle in target_angles_rad]
@@ -304,6 +328,28 @@ class RealRobotInterfaceNode(Node):
         comm_result = self.group_writer.txPacket()
         if comm_result != scs.COMM_SUCCESS:
             self.get_logger().error("GroupSyncWrite txPacket error.", throttle_duration_sec=1.0)
+
+    def on_set_parameters(self, params):
+        # Minimal dynamic handling: enable/disable torque at runtime
+        for p in params:
+            if p.name == 'enable_torque':
+                try:
+                    new_val = bool(p.value)
+                except Exception:
+                    return SetParametersResult(successful=False, reason='enable_torque must be bool')
+                if new_val != getattr(self, 'enable_torque', True):
+                    if new_val:
+                        try:
+                            self._initialize_motors_torque()
+                        except Exception as e:
+                            return SetParametersResult(successful=False, reason=f'Failed to enable torque: {e}')
+                    else:
+                        try:
+                            self._disable_motors_torque()
+                        except Exception as e:
+                            return SetParametersResult(successful=False, reason=f'Failed to disable torque: {e}')
+                    self.enable_torque = new_val
+        return SetParametersResult(successful=True)
             
     def cleanup_resources(self):
         self.get_logger().info("Attempting resource cleanup...")

--- a/src/so100_description/config/urdf.rviz
+++ b/src/so100_description/config/urdf.rviz
@@ -1,0 +1,50 @@
+# RViz2 config for SO-ARM100 URDF visualization
+Panels:
+  - Class: rviz_common/Displays
+    Name: Displays
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Name: Tool Properties
+    Expanded: true
+  - Class: rviz_common/Views
+    Name: Views
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Class: rviz_default_plugins/TF
+      Name: TF
+      Enabled: true
+    - Class: rviz_default_plugins/RobotModel
+      Name: RobotModel
+      Enabled: true
+      Alpha: 1
+      Visual Enabled: true
+      Collision Enabled: false
+      Description Source: Topic
+      Description Topic: /robot_description
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: Base
+  Tools:
+    - Class: rviz_default_plugins/Interact
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Orbit
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Select
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 0.8
+      Focal Point:
+        X: 0.0
+        Y: 0.0
+        Z: 0.1
+      Pitch: 0.6
+      Yaw: 0.8
+      Near Clip Distance: 0.01
+Window Geometry:
+  Height: 800
+  Width: 1200
+  X: 100
+  Y: 100


### PR DESCRIPTION
  **Résumé**

  Simplifie la démo et le monitoring sans tmux. Ajoute un lanceur mock, un moniteur 1‑fenêtre, et un wrapper ROS 2 “propre” pour éviter les conflits conda/ROS. Met à jour le README et restaure une config RViz par défaut.
  
  **Changements**
  
  - scripts/mock_demo.sh: lance vision + contrôleur + interface mock; vérifie les topics; options (camera, weights, conf, FPS, bag).
  - scripts/ros2_cli.sh: wrapper CLI isolé (env ROS propre) pour ros2.
  - scripts/live_status.py: moniteur live en 1 terminal (Hz des topics + statut acquisition + derniers angles).
  - docs(README): ajoute le chemin “Option A — Script mock” + usage du wrapper CLI dans les exemples.
  - so100_description/config/urdf.rviz: config RViz par défaut (Fixed Frame=Base, TF + RobotModel).
  
  **Essai rapide**
  
  - Build/env: `colcon build --packages-select robo_pointer_visual && source scripts/env.sh`
  - Démo mock: `scripts/mock_demo.sh`
  - Monitor 1‑fenêtre: `source scripts/env.sh && python3 scripts/live_status.py
`
- RViz (optionnel): `scripts/ros2_cli.sh launch so100_description display.launch.py
`  
  **Vérifications**
  
  - Fréquences: `scripts/ros2_cli.sh topic hz /image_debug /detected_target_point /target_joint_angles /joint_states`
  - Statut: `scripts/ros2_cli.sh topic echo /detection_acquired --once`
  - Pas de conflit CLI: `scripts/ros2_cli.sh topic list` OK même avec
  conda.
  
  **Impact/Risque**
  
  - Aucun changement dans les nœuds ROS existants; uniquement scripts + docs.
  - CI/tests inchangés; comportement runtime de la pipeline inchangé.
  
  **Motivation**
  
  - Éviter les problèmes d’environnement (numpy/plugins) et réduire le nombre de fenêtres pour la démo.
